### PR TITLE
Update mainIndex.json

### DIFF
--- a/mainIndex.json
+++ b/mainIndex.json
@@ -8247,6 +8247,10 @@
 		}
 	},
 	"vmware-vrealize-log-insight": {
+                "4.7.1": {
+                        "VRLI-471": "794",
+                        "VRLI-471-OSS": "794"
+                },
 		"4.7": {
 			"VRLI-470": "794",
 			"VRLI-470-OSS": "794"


### PR DESCRIPTION
vRLI 4.7.1 standalone added

just deleting mainIndex.json did not help, it gets pulled from repository.
Is there any way to rebuild mainIndex.json from my.vmware.com? This would reduce a lot of (manual?) updates