### PR TITLE
Fix issues where passwords with '%' would be swallowed by printf

### DIFF
--- a/vmw-cli
+++ b/vmw-cli
@@ -19,7 +19,7 @@ cget() {
 	for ITEM in ${CENV[@]}; do
 		if [[ ${ITEM} =~ ([0-9a-zA-Z]+)=(.*)\" ]]; then
 			if [[ "${BASH_REMATCH[1]}" == "${1}" ]]; then
-				printf "${BASH_REMATCH[2]}"
+				echo "${BASH_REMATCH[2]}"
 			fi
 		fi
 	done


### PR DESCRIPTION
This fixes an issue where certain characters (like % or \\) in passwords would
be swallowed up by the printf statement and cause every run to
print `[WARN]: AUTH-CHANGE` and make it impossible to actually
download any specific file.