### PR TITLE
Fix versions from upstream modules

### DIFF
--- a/lib/vmw.api.js
+++ b/lib/vmw.api.js
@@ -46,6 +46,7 @@ module.exports = class vmwApi {
 			expiredInterval: 10 * 60 * 1000, // every 2 minutes the process will clean-up the expired cache
 			forgiveParseErrors: false
 		});
+		this.cache.init();
 	}
 	async main(category, version, type) {
 		try {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "2.1.2",
 	"description": "CLI interface for my.vmware.com",
 	"license": "MIT",
-	"repository": "apnex/vmw-cli",
+	"repository": "remkolodder/vmw-cli",
 	"author": {
 		"name": "Andrew Obersnel"
 	},

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"vmw-sdk": "*",
 		"chalk": "*",
-		"got": "*",
+		"got": "^11.8.2",
 		"md5-file": "*",
 		"node-persist": "*",
 		"p-map": "=4.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "2.1.2",
 	"description": "CLI interface for my.vmware.com",
 	"license": "MIT",
-	"repository": "remkolodder/vmw-cli",
+	"repository": "apnex/vmw-cli",
 	"author": {
 		"name": "Andrew Obersnel"
 	},

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"vmw-sdk": "*",
-		"chalk": "*",
+		"chalk": "=4.1.2",
 		"got": "=11.8.2",
 		"md5-file": "*",
 		"node-persist": "*",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"vmw-sdk": "*",
 		"chalk": "*",
-		"got": "^11.8.2",
+		"got": "=11.8.2",
 		"md5-file": "*",
 		"node-persist": "*",
 		"p-map": "=4.0.0",


### PR DESCRIPTION
The latest versions from Chalk and Got require "ESM" and a different way of using the code. Require becomes import and more changes like that. To fix this, use the old version that is also in the docker image.